### PR TITLE
Depend on opacus 0.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
+opacus==0.15.0
 torch
 torchvision
 simple_parsing
 tqdm
-opacus
 tensorboard


### PR DESCRIPTION
Opacus API changed after v1.0.0, and this causes issues with running our examples with simple installation (see #3).
This PR fixes the opacus version at 0.15.0 until we update our library.